### PR TITLE
Update spigot.yml

### DIFF
--- a/spigot.yml
+++ b/spigot.yml
@@ -149,8 +149,8 @@ world-settings:
       sweetberry-modifier: 100
       kelp-modifier: 100
     max-tick-time:
-      tile: 50
-      entity: 50
+      tile: 60000
+      entity: 60000
     hunger:
       jump-walk-exhaustion: 0.04
       jump-sprint-exhaustion: 0.1


### PR DESCRIPTION
Changing max-tick-time to unrealistically high values (One minute) to ensure that processing of entities is always completed before moving onto the next tick