### PR TITLE
Container update frequency

### DIFF
--- a/paper.yml
+++ b/paper.yml
@@ -144,7 +144,7 @@ world-settings:
     portal-create-radius: 16
     parrots-are-unaffected-by-player-movement: false
     disable-explosion-knockback: false
-    container-update-tick-rate: 2
+    container-update-tick-rate: 1
     armor-stands-do-collision-entity-lookups: true
     disable-thunder: false
     skeleton-horse-thunder-spawn-chance: 0.01
@@ -206,8 +206,8 @@ world-settings:
       MinimumTicks: 100
       MaximumTicks: 600
     despawn-ranges:
-      soft: 32
-      hard: 128
+      soft: 28
+      hard: 96
     frosted-ice:
       enabled: true
       delay:


### PR DESCRIPTION
Changing container update frequency from 2 ticks to 1 tick to make hopper minecart transfer rates reliable. Hopper minecarts are also currently effected by a paper bug, but 1 tick is the vanilla setting.