### PR TITLE
Update tuinity.yml

### DIFF
--- a/tuinity.yml
+++ b/tuinity.yml
@@ -1,7 +1,7 @@
 # Configuration file for Tuinity.
 pistons-can-push-tile-entities: false
 delay-chunkunloads-by: 1
-lag-compensate-block-breaking: true
+lag-compensate-block-breaking: false
 config-version-please-do-not-modify-me: 2
 world-settings:
   default:


### PR DESCRIPTION
Disabling lag compensate block breaking in an attempt to restore vanilla TNT behavior. Recommended to re-enable if no change is observed.