### PR TITLE
Update spigot.yml

### DIFF
--- a/spigot.yml
+++ b/spigot.yml
@@ -99,7 +99,7 @@ world-settings:
       exp: 5.0
     ticks-per:
       hopper-transfer: 8
-      hopper-check: 8
+      hopper-check: 1
     entity-activation-range:
       animals: 32
       monsters: 32


### PR DESCRIPTION
Making hoppers check the container above them every tick (including other hoppers) to make hopper distribution lines reliable. Values above 1 result in items bypassing hoppers they should have entered sometimes, making item filters unreliable